### PR TITLE
fix/Chat-id variable

### DIFF
--- a/telegramRSSbot.py
+++ b/telegramRSSbot.py
@@ -146,7 +146,7 @@ def rss_monitor(context):
             conn.commit()
             conn.close()
             rss_load()
-            context.bot.send_message(chatid, rss_d.entries[0]['link'])
+            context.bot.send_message(CHAT_ID, rss_d.entries[0]['link'])
 
 
 def cmd_test(update, context):


### PR DESCRIPTION
Change the variable from chatId to CHAT_ID. `chatId` isn't defined.